### PR TITLE
Third Party Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ miracle/settings/local.py
 # ignore database dumps, for now
 *.sql
 
+# ignore migrations
+miracle/core/migrations/*
+
 # Google Drive
 *.DS_Store
 

--- a/miracle/core/templates/registration/login.html
+++ b/miracle/core/templates/registration/login.html
@@ -21,8 +21,21 @@
         </form>
     </div>
     <div class='col-md-6'>
-        <h3>Login via Facebook, Google, Twitter</h3>
-        Placeholder to add social auth buttons and badges.
+        <h3>Login via</h3>
+        <ul>
+            <li>
+                <a href="{% url 'social:begin' 'facebook' %}">Facebook</a>
+            </li>
+            <li>
+                <a href="{% url 'social:begin' 'github' %}">GitHub</a>
+            </li>
+            <li>
+                <a href="{% url 'social:begin' 'google-oauth2' %}">Google</a>
+            </li>
+            <li>
+                <a href="{% url 'social:begin' 'twitter' %}">Twitter</a>
+            </li>
+        </ul>
     </div>
 </div>
 {% endblock %}

--- a/miracle/core/tests/test_metadata.py
+++ b/miracle/core/tests/test_metadata.py
@@ -1,6 +1,5 @@
 from .common import BaseMiracleTest, logger
 from ..metadata import Metadata, MetadataFileExtNotFoundError
-import os
 
 
 class MetadataTest(BaseMiracleTest):

--- a/miracle/settings/base.py
+++ b/miracle/settings/base.py
@@ -72,11 +72,20 @@ MIDDLEWARE_CLASSES = (
 # https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#authentication-backends
 
 AUTHENTICATION_BACKENDS = (
+    'social.backends.github.GithubOAuth2',
     'social.backends.facebook.FacebookOAuth2',
     'social.backends.google.GoogleOAuth2',
     'social.backends.twitter.TwitterOAuth',
     'django.contrib.auth.backends.ModelBackend',
 )
+
+#TEMPLATE_CONTEXT_PROCESSORS = (
+#    'social.apps.django_app.context_processors.backends',
+#    'social.apps.django_app.context_processors.login_redirect',
+#)
+
+
+LOGIN_REDIRECT_URL = '/'
 
 ROOT_URLCONF = 'miracle.urls'
 
@@ -87,10 +96,22 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+
+                #'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                #'django.contrib.auth.context_processors.auth',
+                #'django.contrib.messages.context_processors.messages',
+
+
+                'social.apps.django_app.context_processors.backends',
+                'social.apps.django_app.context_processors.login_redirect',
             ],
         },
     },

--- a/miracle/settings/local.py.example
+++ b/miracle/settings/local.py.example
@@ -31,6 +31,18 @@ USE_I18N = False
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'customize this local secret key'
 
+SOCIAL_AUTH_FACEBOOK_KEY = 'customize this local secret key'
+SOCIAL_AUTH_FACEBOOK_SECRET = 'customize this local secret key'
+
+SOCIAL_AUTH_TWITTER_KEY = 'customize this local secret key'
+SOCIAL_AUTH_TWITTER_SECRET = 'customize this local secret key'
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = 'customize this local secret key'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'customize this local secret key'
+
+SOCIAL_AUTH_GITHUB_KEY = 'customize this local secret key'
+SOCIAL_AUTH_GITHUB_SECRET = 'customize this local secret key'
+
 # Enter Zotero API key here
 ZOTERO_API_KEY = None
 

--- a/miracle/urls.py
+++ b/miracle/urls.py
@@ -9,10 +9,12 @@ urlpatterns = [
     # url(r'^$', 'miracle.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url('', include('social.apps.django_app.urls', namespace='social')),
-    url(r'^', include('django.contrib.auth.urls')),
+    url(r'', include('social.apps.django_app.urls', namespace='social')),
+    # need to change this
+    #url(r'^login/$', 'django.contrib.auth.views.login'),
+    url(r'', include('django.contrib.auth.urls')),
     # fallback, core.urls will catch all other unmatched urls
-    url('', include('miracle.core.urls', namespace='core', app_name='core')),
+    url(r'', include('miracle.core.urls', namespace='core', app_name='core')),
 ]
 
 # add user uploaded files to handled urlpatterns in development mode.


### PR DESCRIPTION
These changes allow the user to authenticate using Facebook, GitHub, Google and Twitter. However, I cannot figure out how to redirect to "home" after the user logs out. Right now, it goes to `http://www.miracle.com:8001/logout/` (if localhost is set to www.miracle.com in your /etc/hosts file) which is part of Django Administration. When I try to add a view like (using http://stackoverflow.com/questions/21995917/python-social-auth-django-template-example) 

```python
def logout(request):
    logger.debug(msg='logged out')
    auth_logout(request)
    return redirect('/')
```

and reference the view in `core/urls.py` at `r'^logout/$'` the main template does not seem to use it. If I use a different route though like `r'^logout5/$'` and manually change the url in the browser to `http://www.miracle.com:8001/logout5/` it works as I expect it to,  logging out and redirecting to home. The logout url does was originally using a route in `url(r'', include('django.contrib.auth.urls'))` so I removed that but I still could not figure out how to get the base template to use my logout route.

If it would make it any easier to compare my vagrant machine is at https://github.com/cpritcha/miracle_build 