### PR TITLE
Fixed username already exists error on django container startup, updated postgres image version

### DIFF
--- a/django/entrypoint.sh
+++ b/django/entrypoint.sh
@@ -3,6 +3,6 @@ sleep 10
 python manage.py makemigrations
 python manage.py migrate
 python manage.py collectstatic --noinput
-echo "import os; from django.contrib.auth.models import User; User.objects.create_superuser(os.environ['MIRACLE_USER'], os.environ['MIRACLE_EMAIL'], 'changeme_django')" | python manage.py shell
+echo "import os; from django.contrib.auth.models import User; User.objects.create_superuser(os.environ['MIRACLE_USER'], os.environ['MIRACLE_EMAIL'], 'changeme_django') if not User.objects.filter(username=os.environ['MIRACLE_USER']).exists() else None;" | python manage.py shell
 /usr/bin/supervisord
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -21,7 +21,7 @@ services:
   #### Only need a read_only user for the `miracle_metadata` database
 
   db:
-    image: sameersbn/postgresql:9.4-3
+    image: sameersbn/postgresql:9.4-21
     environment:
       DB_USER: miracle
       DB_PASS: changeme_db


### PR DESCRIPTION
- In the Django container startup script, added a check to see if super user already exists, to remove the "key (username)=(miracle) already exists" error message on container startup.
- Updated postgres image version to 9.4-21
